### PR TITLE
[Team-07] 3주차 2번째 PR

### DIFF
--- a/BE/.gitignore
+++ b/BE/.gitignore
@@ -1,4 +1,5 @@
 **/app_settings
+.jqwik-database
 
 HELP.md
 .gradle

--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -76,6 +76,10 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+test {
+    systemProperty 'spring.profiles.active', 'test'
+}
+
 clean {
     delete file('src/main/generated')
 }

--- a/BE/src/main/java/team07/airbnb/controller/FavoriteController.java
+++ b/BE/src/main/java/team07/airbnb/controller/FavoriteController.java
@@ -41,7 +41,7 @@ public class FavoriteController {
     }
 
     @Tag(name = "User")
-    @Operation(summary = "위시리스트에서 상품 추가")
+    @Operation(summary = "위시리스트에서 상품 삭제")
     @Authenticated(Role.USER)
     @DeleteMapping("/{id}")
     public void removeFavorite(@PathVariable long id, TokenUserInfo user) {

--- a/BE/src/main/java/team07/airbnb/controller/ProductController.java
+++ b/BE/src/main/java/team07/airbnb/controller/ProductController.java
@@ -6,9 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,9 +19,6 @@ import team07.airbnb.common.auth.aop.Authenticated;
 import team07.airbnb.data.product.dto.request.ProductCreateRequest;
 import team07.airbnb.data.product.dto.response.ProductListResponse;
 import team07.airbnb.data.user.dto.response.TokenUserInfo;
-import team07.airbnb.data.user.enums.Role;
-import team07.airbnb.entity.AccommodationEntity;
-import team07.airbnb.exception.auth.UnAuthorizedException;
 import team07.airbnb.service.accommodation.AccommodationService;
 import team07.airbnb.service.product.ProductService;
 import team07.airbnb.service.user.UserService;
@@ -31,8 +26,9 @@ import team07.airbnb.service.user.UserService;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.springframework.http.HttpStatus.*;
-import static team07.airbnb.data.user.enums.Role.*;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+import static team07.airbnb.data.user.enums.Role.HOST;
 
 @Tag(name = "상품")
 @RequestMapping("/products")
@@ -68,10 +64,7 @@ public class ProductController {
     @PostMapping()
     @ResponseStatus(CREATED)
     public void createProduct(@RequestBody ProductCreateRequest request) {
-        AccommodationEntity accommodation = accommodationService.findById(request.accommodationId());
-        int price = request.price() == null ? accommodation.getBasePricePerDay() : request.price();
-
-        accommodation.addProduct(request.date(), price);
+        productService.createProduct(request.accommodationId(), request.date(), request.price());
     }
 
     @Tag(name = "Host")

--- a/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationCreateRequest.java
+++ b/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationCreateRequest.java
@@ -1,11 +1,10 @@
 package team07.airbnb.data.accommodation.dto.request;
 
 import jakarta.validation.constraints.NotNull;
-import org.hibernate.validator.constraints.Range;
+import jakarta.validation.constraints.PositiveOrZero;
 import team07.airbnb.data.accommodation.enums.AccommodationType;
 import team07.airbnb.entity.AccommodationEntity;
 import team07.airbnb.entity.UserEntity;
-import team07.airbnb.entity.embed.AccommodationLocation;
 import team07.airbnb.entity.embed.RoomInformation;
 
 import java.util.ArrayList;
@@ -24,8 +23,8 @@ public record AccommodationCreateRequest(
         String description,
         @NotNull
         List<String> pictures,
-        @NotNull
-        @Range(min = 0)
+
+        @PositiveOrZero
         int basePricePerDay
 ) {
     public AccommodationEntity toEntity(UserEntity host) {

--- a/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationCreateRequest.java
+++ b/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationCreateRequest.java
@@ -1,5 +1,7 @@
 package team07.airbnb.data.accommodation.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
 import team07.airbnb.data.accommodation.enums.AccommodationType;
 import team07.airbnb.entity.AccommodationEntity;
 import team07.airbnb.entity.UserEntity;
@@ -10,12 +12,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 public record AccommodationCreateRequest(
+        @NotNull
         AccommodationType type,
+        @NotNull
         RoomInformation roomInformation,
-        AccommodationLocation address,
+        @NotNull
+        AccommodationLocationRequest address,
+        @NotNull
         String name,
+        @NotNull
         String description,
+        @NotNull
         List<String> pictures,
+        @NotNull
+        @Range(min = 0)
         int basePricePerDay
 ) {
     public AccommodationEntity toEntity(UserEntity host) {
@@ -23,7 +33,7 @@ public record AccommodationCreateRequest(
                 .host(host)
                 .type(type)
                 .roomInformation(roomInformation)
-                .address(address)
+                .address(address.toLocation())
                 .name(name)
                 .description(description)
                 .pictures(new ArrayList<>())

--- a/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationLocationRequest.java
+++ b/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationLocationRequest.java
@@ -29,11 +29,11 @@ public record AccommodationLocationRequest(
         return new AccommodationLocation(
                 this.address,
                 this.zipCode,
-                getPoint()
+                point()
         );
     }
 
-    public Point getPoint() {
+    public Point point() {
         Point pointType = new GeometryFactory().createPoint(new Coordinate(longitude, latitude));
         pointType.setSRID(4326);
 

--- a/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationLocationRequest.java
+++ b/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationLocationRequest.java
@@ -1,7 +1,8 @@
 package team07.airbnb.data.accommodation.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import org.hibernate.validator.constraints.Range;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
@@ -12,15 +13,15 @@ public record AccommodationLocationRequest(
         String address,
 
         @NotNull
-        @Range(min = 10000, max = 99999)
+        @Min(10000) @Max(99999)
         Integer zipCode,
 
         @NotNull
-        @Range(min = -180, max = 180)
+        @Min(-180) @Max(180)
         Double longitude,
 
         @NotNull
-        @Range(min = -90, max = 90)
+        @Min(-90) @Max(90)
         Double latitude
 ) {
 

--- a/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationLocationRequest.java
+++ b/BE/src/main/java/team07/airbnb/data/accommodation/dto/request/AccommodationLocationRequest.java
@@ -1,0 +1,41 @@
+package team07.airbnb.data.accommodation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import team07.airbnb.entity.embed.AccommodationLocation;
+
+public record AccommodationLocationRequest(
+        @NotNull
+        String address,
+
+        @NotNull
+        @Range(min = 10000, max = 99999)
+        Integer zipCode,
+
+        @NotNull
+        @Range(min = -180, max = 180)
+        Double longitude,
+
+        @NotNull
+        @Range(min = -90, max = 90)
+        Double latitude
+) {
+
+    public AccommodationLocation toLocation() {
+        return new AccommodationLocation(
+                this.address,
+                this.zipCode,
+                getPoint()
+        );
+    }
+
+    public Point getPoint() {
+        Point pointType = new GeometryFactory().createPoint(new Coordinate(longitude, latitude));
+        pointType.setSRID(4326);
+
+        return pointType;
+    }
+}

--- a/BE/src/main/java/team07/airbnb/data/booking/dto/PriceInfo.java
+++ b/BE/src/main/java/team07/airbnb/data/booking/dto/PriceInfo.java
@@ -3,8 +3,10 @@ package team07.airbnb.data.booking.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class PriceInfo {
 
@@ -12,10 +14,6 @@ public class PriceInfo {
     private int discountPrice;
     private int serviceFee;
     private int accommodationFee;
-
-    public boolean isEmpty() {
-        return roughTotalPrice == 0 || discountPrice == 0 || serviceFee == 0 || accommodationFee == 0;
-    }
 
     public static PriceInfo of(int roughTotalPrice, int discountPrice, int serviceFee, int accommodationFee) {
         return new PriceInfo(

--- a/BE/src/main/java/team07/airbnb/data/booking/dto/request/BookingPaymentsRequest.java
+++ b/BE/src/main/java/team07/airbnb/data/booking/dto/request/BookingPaymentsRequest.java
@@ -1,6 +1,10 @@
 package team07.airbnb.data.booking.dto.request;
 
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import team07.airbnb.common.validation.CheckOutAfterCheckIn;
 
 import java.time.LocalDate;
@@ -8,14 +12,19 @@ import java.time.LocalDate;
 @CheckOutAfterCheckIn
 public record BookingPaymentsRequest(
         @NotNull
+        @FutureOrPresent
         LocalDate checkIn,
         @NotNull
+        @FutureOrPresent
         LocalDate checkOut,
         @NotNull
+        @Min(-180) @Max(180)
         Double longitude,
         @NotNull
+        @Min(-90) @Max(90)
         Double latitude,
         @NotNull
+        @Positive
         Double distance
 ) {
 }

--- a/BE/src/main/java/team07/airbnb/data/booking/dto/request/BookingRequest.java
+++ b/BE/src/main/java/team07/airbnb/data/booking/dto/request/BookingRequest.java
@@ -1,8 +1,10 @@
 package team07.airbnb.data.booking.dto.request;
 
-import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import team07.airbnb.common.validation.CheckOutAfterCheckIn;
 
 import java.time.LocalDate;
@@ -10,12 +12,13 @@ import java.time.LocalDate;
 @CheckOutAfterCheckIn
 public record BookingRequest(
         @NotNull
+        @Positive
         Long accommodationId,
         @NotNull
-        @Future
+        @FutureOrPresent
         LocalDate checkIn,
         @NotNull
-        @Future
+        @FutureOrPresent
         LocalDate checkOut,
         @NotNull
         Integer headCount

--- a/BE/src/main/java/team07/airbnb/data/product/dto/request/ProductCreateRequest.java
+++ b/BE/src/main/java/team07/airbnb/data/product/dto/request/ProductCreateRequest.java
@@ -1,10 +1,22 @@
 package team07.airbnb.data.product.dto.request;
 
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
 import java.time.LocalDate;
 
 public record ProductCreateRequest(
+        @Positive
         long accommodationId,
+
+        @NotNull
+        @FutureOrPresent
         LocalDate date,
+
+        @NotNull
+        @PositiveOrZero
         Integer price
 ) {
 }

--- a/BE/src/main/java/team07/airbnb/data/review/dto/request/ReviewPostRequest.java
+++ b/BE/src/main/java/team07/airbnb/data/review/dto/request/ReviewPostRequest.java
@@ -1,7 +1,12 @@
 package team07.airbnb.data.review.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
 public record ReviewPostRequest(
         String content,
+
+        @Min(0) @Max(5)
         int rating
 ) {
 }

--- a/BE/src/main/java/team07/airbnb/entity/AccommodationEntity.java
+++ b/BE/src/main/java/team07/airbnb/entity/AccommodationEntity.java
@@ -24,6 +24,7 @@ import team07.airbnb.entity.embed.RoomInformation;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Table(name = "ACCOMMODATION")
@@ -62,11 +63,12 @@ public class AccommodationEntity extends BaseEntity {
     @OneToMany(mappedBy = "accommodation", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProductEntity> products = new ArrayList<>();
 
-    @Transient
     public List<ReviewEntity> reviews() {
         return products.stream()
                 .map(ProductEntity::getBooking)
+                .filter(Objects::nonNull)
                 .map(BookingEntity::getReview)
+                .filter(Objects::nonNull)
                 .toList();
     }
 

--- a/BE/src/main/java/team07/airbnb/entity/embed/AccommodationLocation.java
+++ b/BE/src/main/java/team07/airbnb/entity/embed/AccommodationLocation.java
@@ -1,13 +1,17 @@
 package team07.airbnb.entity.embed;
 
 import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.locationtech.jts.geom.Point;
 
 @Embeddable
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@ToString
 public class AccommodationLocation {
     private String address;
     private Integer zipCode;

--- a/BE/src/main/java/team07/airbnb/entity/embed/RoomInformation.java
+++ b/BE/src/main/java/team07/airbnb/entity/embed/RoomInformation.java
@@ -1,17 +1,21 @@
 package team07.airbnb.entity.embed;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Embeddable
+@NoArgsConstructor
 @Getter
 public class RoomInformation {
     private int bedCount;
     private int bedroomCount;
     private int bathroomCount;
+    @JsonProperty("private")
     private boolean isPrivate;
     private int maxOccupancy;
 }

--- a/BE/src/main/java/team07/airbnb/entity/embed/RoomInformation.java
+++ b/BE/src/main/java/team07/airbnb/entity/embed/RoomInformation.java
@@ -1,6 +1,7 @@
 package team07.airbnb.entity.embed;
 
 import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.ToString;
 

--- a/BE/src/main/java/team07/airbnb/entity/embed/RoomInformation.java
+++ b/BE/src/main/java/team07/airbnb/entity/embed/RoomInformation.java
@@ -2,7 +2,9 @@ package team07.airbnb.entity.embed;
 
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
+import lombok.ToString;
 
+@ToString
 @Embeddable
 @Getter
 public class RoomInformation {

--- a/BE/src/main/java/team07/airbnb/service/booking/BookingManageService.java
+++ b/BE/src/main/java/team07/airbnb/service/booking/BookingManageService.java
@@ -43,9 +43,6 @@ public class BookingManageService {
 
     public BookingCreateResponse createBooking(BookingInfoForPriceInfo bookingInfo, Long accId, UserEntity booker) {
         PriceInfo priceInfo = bookingPriceService.getPriceInfo(bookingInfo);
-        if (priceInfo.isEmpty()) {
-            throw new InvalidBookingRequestException(bookingInfo);
-        }
 
         PaymentEntity payment = paymentService.createNewPayment(priceInfo);
         LocalDate checkIn = bookingInfo.checkIn();

--- a/BE/src/main/java/team07/airbnb/service/product/ProductService.java
+++ b/BE/src/main/java/team07/airbnb/service/product/ProductService.java
@@ -123,4 +123,10 @@ public class ProductService {
 
         return dateSet.isEmpty();
     }
+
+    public void createProduct(long accommodationId, LocalDate date, Integer requestPrice) {
+        AccommodationEntity accommodation = accommodationService.findById(accommodationId);
+        int price = requestPrice == null ? accommodation.getBasePricePerDay() : requestPrice;
+        accommodation.addProduct(date, price);
+    }
 }

--- a/BE/src/main/java/team07/airbnb/service/product/ProductService.java
+++ b/BE/src/main/java/team07/airbnb/service/product/ProductService.java
@@ -100,8 +100,8 @@ public class ProductService {
     }
 
     private boolean isAvailablePeopleCount(List<ProductEntity> products, Integer headCount) {
-        //인원수를 설정하지 않았으면 무조건 true
-        if (headCount == null) return true;
+        //인원수가 1이면 무조건 true
+        if (headCount == 1) return true;
 
         if (products.isEmpty()) return false;
 

--- a/BE/src/main/resources/sql/schema.sql
+++ b/BE/src/main/resources/sql/schema.sql
@@ -149,3 +149,7 @@ CREATE TABLE USER_LIKES_PRODUCT
     constraint user_id foreign key (user_id) references USERS (id)
 );
 
+ALTER TABLE ACCOMMODATION MODIFY point POINT NOT NULL SRID 4326;
+CREATE SPATIAL INDEX point_spatial_index ON ACCOMMODATION(point);
+
+insert into DISCOUNT_POLICY values (null, "주단위할인", 'weeklyRateDiscountPolicy', null, null);

--- a/BE/src/main/resources/sql/test.sql
+++ b/BE/src/main/resources/sql/test.sql
@@ -1,0 +1,3 @@
+INSERT INTO USERS(name , picture , role)
+VALUES ("호스트", "hostPicture", "HOST"),
+       ("게스트", "guestPicture", "USER");

--- a/BE/src/test/java/team07/airbnb/FixtureMonkeyTest.java
+++ b/BE/src/test/java/team07/airbnb/FixtureMonkeyTest.java
@@ -1,10 +1,10 @@
 package team07.airbnb;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
-import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import team07.airbnb.data.accommodation.dto.request.AccommodationCreateRequest;
 import team07.airbnb.data.accommodation.dto.request.AccommodationDescriptionRequest;
 import team07.airbnb.data.accommodation.dto.request.BaseAccommodationInfoRequest;
@@ -12,23 +12,22 @@ import team07.airbnb.data.booking.dto.request.BookingPaymentsRequest;
 import team07.airbnb.data.booking.dto.request.BookingRequest;
 import team07.airbnb.data.product.dto.request.ProductCreateRequest;
 
+@SpringBootTest
 public class FixtureMonkeyTest {
 
-    private final FixtureMonkey sut = FixtureMonkey.builder()
-            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
-            .plugin(new JakartaValidationPlugin())
-            .build();
+    @Autowired
+    FixtureMonkey monkey;
 
     @DisplayName("")
     @Test
     void test() {
         // given
-        System.out.println(sut.giveMeOne(AccommodationCreateRequest.class));
-        System.out.println(sut.giveMeOne(AccommodationDescriptionRequest.class));
-        System.out.println(sut.giveMeOne(BaseAccommodationInfoRequest.class));
-        System.out.println(sut.giveMeOne(BookingRequest.class));
-        System.out.println(sut.giveMeOne(BookingPaymentsRequest.class));
-        System.out.println(sut.giveMeOne(ProductCreateRequest.class));
+        System.out.println(monkey.giveMeOne(AccommodationCreateRequest.class));
+        System.out.println(monkey.giveMeOne(AccommodationDescriptionRequest.class));
+        System.out.println(monkey.giveMeOne(BaseAccommodationInfoRequest.class));
+        System.out.println(monkey.giveMeOne(BookingRequest.class));
+        System.out.println(monkey.giveMeOne(BookingPaymentsRequest.class));
+        System.out.println(monkey.giveMeOne(ProductCreateRequest.class));
         // when
 
         //then

--- a/BE/src/test/java/team07/airbnb/FixtureMonkeyTest.java
+++ b/BE/src/test/java/team07/airbnb/FixtureMonkeyTest.java
@@ -1,0 +1,37 @@
+package team07.airbnb;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import team07.airbnb.data.accommodation.dto.request.AccommodationCreateRequest;
+import team07.airbnb.data.accommodation.dto.request.AccommodationDescriptionRequest;
+import team07.airbnb.data.accommodation.dto.request.BaseAccommodationInfoRequest;
+import team07.airbnb.data.booking.dto.request.BookingPaymentsRequest;
+import team07.airbnb.data.booking.dto.request.BookingRequest;
+import team07.airbnb.data.product.dto.request.ProductCreateRequest;
+
+public class FixtureMonkeyTest {
+
+    private final FixtureMonkey sut = FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .plugin(new JakartaValidationPlugin())
+            .build();
+
+    @DisplayName("")
+    @Test
+    void test() {
+        // given
+        System.out.println(sut.giveMeOne(AccommodationCreateRequest.class));
+        System.out.println(sut.giveMeOne(AccommodationDescriptionRequest.class));
+        System.out.println(sut.giveMeOne(BaseAccommodationInfoRequest.class));
+        System.out.println(sut.giveMeOne(BookingRequest.class));
+        System.out.println(sut.giveMeOne(BookingPaymentsRequest.class));
+        System.out.println(sut.giveMeOne(ProductCreateRequest.class));
+        // when
+
+        //then
+    }
+
+}

--- a/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
@@ -1,24 +1,130 @@
 package team07.airbnb.integration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.navercorp.fixturemonkey.FixtureMonkey;
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+import team07.airbnb.data.booking.dto.request.BookingRequest;
+import team07.airbnb.data.booking.dto.response.BookingCreateResponse;
+import team07.airbnb.entity.AccommodationEntity;
+import team07.airbnb.entity.ProductEntity;
+import team07.airbnb.integration.util.AuthHelper;
+import team07.airbnb.integration.util.DataBaseHelper;
 import team07.airbnb.integration.util.Request;
+import team07.airbnb.integration.util.TestConfig;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static team07.airbnb.data.user.enums.Role.HOST;
+import static team07.airbnb.data.user.enums.Role.USER;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class BookingApiTest {
+@Import(TestConfig.class)
+class BookingApiTest {
 
+    //utils
     @Autowired
     Request hostRequest;
+
     @Autowired
-    Request guestRequest;
+    Request userRequest;
+
+    @Autowired
+    DataBaseHelper dataBaseHelper;
+
+    @Autowired
+    AuthHelper auth;
+
+    @Autowired
+    FixtureMonkey monkey;
+
+    //settings
     @LocalServerPort
     int port;
 
     @BeforeEach
     void setUp() {
+        dataBaseHelper.clear();
+
+        createDummyAccommodation();
+
         RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("존재하는 숙소에 상품, 날짜, 인원수가 정상적으로 설정되었으면 예약이 만들어져야함")
+    void bookingCreateTest() throws JsonProcessingException {
+        //given
+        BookingRequest dummyRequest = monkey.giveMeBuilder(BookingRequest.class)
+                .set("accommodationId", 1L)
+                .set("checkIn", LocalDate.now())
+                .set("checkOut", LocalDate.now().plusDays(5L))
+                .set("headCount", 1)
+                .sample();
+
+
+        //when
+        BookingCreateResponse response = userRequest.post(dummyRequest, "/booking", BookingCreateResponse.class);
+
+        //then
+        assertThat(response.checkIn()).isEqualTo(LocalDate.now());
+        assertThat(response.checkOut()).isEqualTo(LocalDate.now().plusDays(5L));
+        assertThat(response.headCount()).isEqualTo(1);
+        assertThat(response.bookingId()).isEqualTo(1L);
+
+    }
+
+    void createDummyAccommodation() {
+        List<Object> dummies = new ArrayList<>();
+        AccommodationEntity dummyAC = monkey
+                                        .giveMeBuilder(AccommodationEntity.class)
+                                        .set("id", null)
+                                        .sample();
+        dummies.add(dummyAC);
+        for (long i = 0; i < 10; i++) {
+            dummies.add(ProductEntity.ofOpen(dummyAC, LocalDate.now().plusDays(i), 10000));
+        }
+        dataBaseHelper.put(dummies);
+    }
+
+    @Test
+    void test() throws JsonProcessingException {
+        //given
+        BookingRequest dummyRequest = monkey.giveMeBuilder(BookingRequest.class)
+                .set("accommodationId", 1L)
+                .set("checkIn", LocalDate.now())
+                .set("checkOut", LocalDate.now().plusDays(5L))
+                .set("headCount", 1)
+                .sample();
+
+
+        //when
+        BookingCreateResponse response = userRequest.post(dummyRequest, "/booking", BookingCreateResponse.class);
+
+        //then
+        assertThat(response.checkIn()).isEqualTo(LocalDate.now());
+        assertThat(response.checkOut()).isEqualTo(LocalDate.now().plusDays(5L));
+        assertThat(response.headCount()).isEqualTo(1);
+        assertThat(response.bookingId()).isEqualTo(1L);
+    }
+
+
+    @AfterEach
+    void shutDown() {
+        System.out.println("shutdown");
+        auth.logout();
+        dataBaseHelper.clear();
     }
 }

--- a/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
+import team07.airbnb.data.booking.dto.PriceInfo;
 import team07.airbnb.data.booking.dto.request.BookingRequest;
 import team07.airbnb.data.booking.dto.response.BookingCreateResponse;
 import team07.airbnb.entity.AccommodationEntity;
@@ -40,6 +41,9 @@ class BookingApiTest {
 
     @Autowired
     Request userRequest;
+
+    @Autowired
+    Request otherRequest;
 
     @Autowired
     DataBaseHelper dataBaseHelper;
@@ -86,6 +90,24 @@ class BookingApiTest {
 
     }
 
+    @Test
+    void getBookingPriceTest() throws JsonProcessingException {
+        //given
+        BookingRequest dummyRequest = monkey.giveMeBuilder(BookingRequest.class)
+                .set("accommodationId", 1L)
+                .set("checkIn", LocalDate.now())
+                .set("checkOut", LocalDate.now().plusDays(5L))
+                .set("headCount", 1)
+                .sample();
+
+        //when
+        PriceInfo response = otherRequest.get(dummyRequest, "/booking", PriceInfo.class);
+
+        //then
+        assertThat(response.getRoughTotalPrice()).isEqualTo(60000);
+        assertThat(response.getDiscountPrice()).isEqualTo((int) (60000 * 0.04));
+    }
+
     void createDummyAccommodation() {
         List<Object> dummies = new ArrayList<>();
         AccommodationEntity dummyAC = monkey
@@ -99,32 +121,9 @@ class BookingApiTest {
         dataBaseHelper.put(dummies);
     }
 
-    @Test
-    void test() throws JsonProcessingException {
-        //given
-        BookingRequest dummyRequest = monkey.giveMeBuilder(BookingRequest.class)
-                .set("accommodationId", 1L)
-                .set("checkIn", LocalDate.now())
-                .set("checkOut", LocalDate.now().plusDays(5L))
-                .set("headCount", 1)
-                .sample();
-
-
-        //when
-        BookingCreateResponse response = userRequest.post(dummyRequest, "/booking", BookingCreateResponse.class);
-
-        //then
-        assertThat(response.checkIn()).isEqualTo(LocalDate.now());
-        assertThat(response.checkOut()).isEqualTo(LocalDate.now().plusDays(5L));
-        assertThat(response.headCount()).isEqualTo(1);
-        assertThat(response.bookingId()).isEqualTo(1L);
-    }
-
-
     @AfterEach
     void shutDown() {
         System.out.println("shutdown");
-        auth.logout();
         dataBaseHelper.clear();
     }
 }

--- a/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
@@ -1,0 +1,4 @@
+package team07.airbnb.integration;
+
+public class BookingApiTest {
+}

--- a/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
@@ -1,11 +1,7 @@
 package team07.airbnb.integration;
 
 import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;

--- a/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/BookingApiTest.java
@@ -1,4 +1,38 @@
 package team07.airbnb.integration;
 
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import team07.airbnb.integration.util.Request;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class BookingApiTest {
+
+    @Autowired
+    Request request;
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp()
+    {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("")
+    @Test
+    void test() {
+        // given
+        ExtractableResponse<Response> response = request.get("favorite/my");
+        // when
+
+        //then
+        System.out.println(response.body());
+    }
 }

--- a/BE/src/test/java/team07/airbnb/integration/FavoriteTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/FavoriteTest.java
@@ -29,7 +29,7 @@ public class FavoriteTest {
     @Autowired
     Request hostRequest;
     @Autowired
-    Request guestRequest;
+    Request userRequest;
     @Autowired
     FixtureMonkey monkey;
     @Autowired
@@ -55,10 +55,10 @@ public class FavoriteTest {
 
         ProductCreateRequest pro = new ProductCreateRequest(created.id() , LocalDate.now(), 1000);
         hostRequest.post(pro, "/products");
-        guestRequest.post(null, "/favorite/" + 1);
+        userRequest.post(null, "/favorite/" + 1);
 
         // when
-        FavoritesResponse response = guestRequest.get("favorite/my", FavoritesResponse.class);
+        FavoritesResponse response = userRequest.get("favorite/my", FavoritesResponse.class);
 
         //then
         assertThat(response.available()).hasSize(1);

--- a/BE/src/test/java/team07/airbnb/integration/FavoriteTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/FavoriteTest.java
@@ -1,5 +1,6 @@
 package team07.airbnb.integration;
 
+import com.navercorp.fixturemonkey.FixtureMonkey;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -12,17 +13,33 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import team07.airbnb.integration.util.Request;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class BookingApiTest {
+public class FavoriteTest {
 
     @Autowired
     Request hostRequest;
     @Autowired
     Request guestRequest;
+    @Autowired
+    FixtureMonkey monkey;
     @LocalServerPort
     int port;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+    }
+
+    @DisplayName("")
+    @Test
+    void test() {
+        // give
+
+        // when
+        ExtractableResponse<Response> response = hostRequest.get("favorite/my");
+        ExtractableResponse<Response> response2 = guestRequest.get("favorite/my");
+
+        //then
+        System.out.println(response.body());
+        System.out.println(response2.body());
     }
 }

--- a/BE/src/test/java/team07/airbnb/integration/FavoriteTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/FavoriteTest.java
@@ -1,18 +1,28 @@
 package team07.airbnb.integration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Profile;
+import team07.airbnb.data.accommodation.dto.request.AccommodationCreateRequest;
+import team07.airbnb.data.accommodation.dto.response.AccommodationListResponse;
+import team07.airbnb.data.product.dto.request.ProductCreateRequest;
+import team07.airbnb.data.user.dto.response.FavoritesResponse;
+import team07.airbnb.integration.util.DataBaseHelper;
 import team07.airbnb.integration.util.Request;
 
+import java.time.LocalDate;
+
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Profile("test")
 public class FavoriteTest {
 
     @Autowired
@@ -21,6 +31,8 @@ public class FavoriteTest {
     Request guestRequest;
     @Autowired
     FixtureMonkey monkey;
+    @Autowired
+    DataBaseHelper dataBaseHelper;
     @LocalServerPort
     int port;
 
@@ -28,18 +40,26 @@ public class FavoriteTest {
     void setUp() {
         RestAssured.port = port;
     }
+    @AfterEach
+    void tearDown() {
+        dataBaseHelper.clear();
+    }
 
-    @DisplayName("")
+    @DisplayName("유저는 상품을 위시리스트에 추가할 수 있다.")
     @Test
-    void test() {
-        // give
+    void test() throws JsonProcessingException {
+        // given
+        AccommodationCreateRequest acc = monkey.giveMeOne(AccommodationCreateRequest.class);
+        AccommodationListResponse created = hostRequest.post(acc, "/accommodation", AccommodationListResponse.class);
+
+        ProductCreateRequest pro = new ProductCreateRequest(created.id() , LocalDate.now(), 1000);
+        hostRequest.post(pro, "/products");
+        guestRequest.post(null, "/favorite/" + 1);
 
         // when
-        ExtractableResponse<Response> response = hostRequest.get("favorite/my");
-        ExtractableResponse<Response> response2 = guestRequest.get("favorite/my");
+        FavoritesResponse response = guestRequest.get("favorite/my", FavoritesResponse.class);
 
         //then
-        System.out.println(response.body());
-        System.out.println(response2.body());
+        Assertions.assertThat(response.available()).hasSize(1);
     }
 }

--- a/BE/src/test/java/team07/airbnb/integration/ProductApiTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/ProductApiTest.java
@@ -1,4 +1,50 @@
 package team07.airbnb.integration;
 
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Profile;
+import team07.airbnb.integration.util.DataBaseHelper;
+import team07.airbnb.integration.util.Request;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Profile("test")
 public class ProductApiTest {
+
+    @Autowired
+    Request hostRequest;
+    @Autowired
+    Request userRequest;
+    @Autowired
+    FixtureMonkey monkey;
+    @Autowired
+    DataBaseHelper dataBaseHelper;
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataBaseHelper.clear();
+    }
+
+    @DisplayName("")
+    @Test
+    void test() {
+        // given
+
+        // when
+
+        //then
+    }
 }

--- a/BE/src/test/java/team07/airbnb/integration/ProductApiTest.java
+++ b/BE/src/test/java/team07/airbnb/integration/ProductApiTest.java
@@ -1,0 +1,4 @@
+package team07.airbnb.integration;
+
+public class ProductApiTest {
+}

--- a/BE/src/test/java/team07/airbnb/integration/util/AuthHelper.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/AuthHelper.java
@@ -1,0 +1,42 @@
+package team07.airbnb.integration.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import team07.airbnb.common.auth.jwt.JwtUserDetails;
+import team07.airbnb.common.auth.jwt.JwtUtil;
+import team07.airbnb.data.user.dto.response.TokenUserInfo;
+import team07.airbnb.data.user.enums.Role;
+import team07.airbnb.entity.UserEntity;
+
+import java.util.ArrayList;
+
+@Component
+public class AuthHelper {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional
+    public String login(Role role) throws JsonProcessingException {
+        UserEntity dummyUser = new UserEntity(null, "", "testUser", "test@test.com", role, "regTest", new ArrayList<>());
+        entityManager.persist(dummyUser);
+
+        TokenUserInfo dummyTUI = TokenUserInfo.of(dummyUser);
+        JwtUserDetails dummyDetails = new JwtUserDetails(dummyTUI, null);
+
+
+        return jwtUtil.generateToken(dummyDetails);
+    }
+
+    @Transactional
+    public void logout() {
+        entityManager.createNativeQuery("truncate table USERS");
+    }
+}

--- a/BE/src/test/java/team07/airbnb/integration/util/AuthHelper.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/AuthHelper.java
@@ -3,6 +3,7 @@ package team07.airbnb.integration.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterAll;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import team07.airbnb.entity.UserEntity;
 import java.util.ArrayList;
 
 @Component
+@Transactional
 public class AuthHelper {
 
     @Autowired
@@ -23,7 +25,6 @@ public class AuthHelper {
     @PersistenceContext
     private EntityManager entityManager;
 
-    @Transactional
     public String login(Role role) throws JsonProcessingException {
         UserEntity dummyUser = new UserEntity(null, "", "testUser", "test@test.com", role, "regTest", new ArrayList<>());
         entityManager.persist(dummyUser);
@@ -35,8 +36,10 @@ public class AuthHelper {
         return jwtUtil.generateToken(dummyDetails);
     }
 
-    @Transactional
+
     public void logout() {
-        entityManager.createNativeQuery("truncate table USERS");
+        entityManager.createNativeQuery("TRUNCATE TABLE USERS");
+        entityManager.flush();
+        entityManager.clear();
     }
 }

--- a/BE/src/test/java/team07/airbnb/integration/util/AuthHelper.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/AuthHelper.java
@@ -26,8 +26,9 @@ public class AuthHelper {
     private EntityManager entityManager;
 
     public String login(Role role) throws JsonProcessingException {
-        UserEntity dummyUser = new UserEntity(null, "", "testUser", "test@test.com", role, "regTest", new ArrayList<>());
+        UserEntity dummyUser = new UserEntity(null, "", role.getTitle(), "test@test.com", role, "regTest", new ArrayList<>());
         entityManager.persist(dummyUser);
+        entityManager.flush();
 
         TokenUserInfo dummyTUI = TokenUserInfo.of(dummyUser);
         JwtUserDetails dummyDetails = new JwtUserDetails(dummyTUI, null);

--- a/BE/src/test/java/team07/airbnb/integration/util/DataBaseCleaner.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/DataBaseCleaner.java
@@ -8,7 +8,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Component
 @Profile("test")
@@ -30,14 +33,17 @@ public class DataBaseCleaner {
     }
 
     @Transactional
-    public void clear() {
+    public void clear(String ... withOuts) {
         entityManager.clear();
-        truncate();
+        Set<String> names = new HashSet<>(Arrays.asList(withOuts));
+        names.add("USERS"); // 유저 테이블은 초기화 제외
+        truncate(names);
     }
 
-    private void truncate() {
+    private void truncate(Set<String> withOut) {
         entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECK_FORMAT, 0)).executeUpdate(); // FK 제약조건 해제
         for (String tableName : tableNames) {
+            if(withOut.contains(tableName)) continue;
             entityManager.createNativeQuery(String.format(TRUNCATE_FORMAT, tableName)).executeUpdate();
         }
         entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECK_FORMAT, 1)).executeUpdate();

--- a/BE/src/test/java/team07/airbnb/integration/util/DataBaseCleaner.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/DataBaseCleaner.java
@@ -1,0 +1,45 @@
+package team07.airbnb.integration.util;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Profile("test")
+public class DataBaseCleaner {
+
+    private static final String FOREIGN_KEY_CHECK_FORMAT = "SET FOREIGN_KEY_CHECKS %d";
+    private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
+
+    private final List<String> tableNames = new ArrayList<>();
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @SuppressWarnings("unchecked")
+    @PostConstruct
+    public void findDatabaseTableNames() {
+        List<String> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
+        tableNames.addAll(tableInfos);
+    }
+
+    @Transactional
+    public void clear() {
+        entityManager.clear();
+        truncate();
+    }
+
+    private void truncate() {
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECK_FORMAT, 0)).executeUpdate(); // FK 제약조건 해제
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery(String.format(TRUNCATE_FORMAT, tableName)).executeUpdate();
+        }
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECK_FORMAT, 1)).executeUpdate();
+    }
+}

--- a/BE/src/test/java/team07/airbnb/integration/util/DataBaseHelper.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/DataBaseHelper.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 @Component
 @Profile("test")
-public class DataBaseCleaner {
+public class DataBaseHelper {
 
     private static final String FOREIGN_KEY_CHECK_FORMAT = "SET FOREIGN_KEY_CHECKS %d";
     private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
@@ -33,17 +33,26 @@ public class DataBaseCleaner {
     }
 
     @Transactional
-    public void clear(String ... withOuts) {
+    public void clear(String... withOuts) {
         entityManager.clear();
         Set<String> names = new HashSet<>(Arrays.asList(withOuts));
         names.add("USERS"); // 유저 테이블은 초기화 제외
+        names.add("DISCOUNT_POLICY");
         truncate(names);
+    }
+
+    @Transactional
+    public void put(List<Object> dummies) {
+        for (Object dummy : dummies) {
+            entityManager.persist(dummy);
+        }
+        entityManager.flush();
     }
 
     private void truncate(Set<String> withOut) {
         entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECK_FORMAT, 0)).executeUpdate(); // FK 제약조건 해제
         for (String tableName : tableNames) {
-            if(withOut.contains(tableName)) continue;
+            if (withOut.contains(tableName)) continue;
             entityManager.createNativeQuery(String.format(TRUNCATE_FORMAT, tableName)).executeUpdate();
         }
         entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECK_FORMAT, 1)).executeUpdate();

--- a/BE/src/test/java/team07/airbnb/integration/util/DataBaseHelper.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/DataBaseHelper.java
@@ -39,7 +39,6 @@ public class DataBaseHelper {
         names.add("USERS"); // 유저 테이블은 초기화 제외
         names.add("DISCOUNT_POLICY");
         truncate(names);
-        entityManager.close();
     }
 
     public void put(List<Object> dummies) {
@@ -48,8 +47,6 @@ public class DataBaseHelper {
             if (entityManager.contains(dummy)) entityManager.merge(dummy);
             else entityManager.persist(dummy);
         }
-
-        entityManager.close();
     }
 
     private void truncate(Set<String> withOut) {

--- a/BE/src/test/java/team07/airbnb/integration/util/Request.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/Request.java
@@ -6,22 +6,32 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 
 @Component
+@Scope("prototype")
 public class Request {
 
     @Autowired
     private ObjectMapper customObjectMapper;
 
-    @Value("${jwt.host}")
-    private String HOST_TOKEN;
+    private String jwtToken;
+
+    public void setJwtToken(String jwtToken) {
+        this.jwtToken = jwtToken;
+    }
+
+//    private void applyJwtToken() {
+//        if (jwtToken != null) {
+//            RestAssured.given().header("Authorization", "Bearer " + jwtToken);
+//        }
+//    }
 
     public ExtractableResponse<Response> get(String url) {
         return RestAssured.given().log().all()
-//                .auth().oauth2(HOST_TOKEN)
+                .auth().oauth2(jwtToken)
                 .when()
                 .get(url)
                 .then().log().all()
@@ -30,6 +40,7 @@ public class Request {
 
     public ExtractableResponse<Response> post(Object params, String url) throws JsonProcessingException {
         return RestAssured.given().log().all()
+                .auth().oauth2(jwtToken)
                 .body(customObjectMapper.writeValueAsString(params))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
@@ -40,6 +51,7 @@ public class Request {
 
     public ExtractableResponse<Response> put(Object params, String url) throws JsonProcessingException {
         return RestAssured.given().log().all()
+                .auth().oauth2(jwtToken)
                 .body(customObjectMapper.writeValueAsString(params))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
@@ -50,17 +62,19 @@ public class Request {
 
     public ExtractableResponse<Response> patch(Object params, String url) throws JsonProcessingException {
         return RestAssured.given().log().all()
-            .body(customObjectMapper.writeValueAsString(params))
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when()
-            .patch(url)
-            .then()
-            .log().all()
-            .extract();
+                .auth().oauth2(jwtToken)
+                .body(customObjectMapper.writeValueAsString(params))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .patch(url)
+                .then()
+                .log().all()
+                .extract();
     }
 
     public ExtractableResponse<Response> delete(String url) {
         return RestAssured.given().log().all()
+                .auth().oauth2(jwtToken)
                 .when()
                 .delete(url)
                 .then().log().all()

--- a/BE/src/test/java/team07/airbnb/integration/util/Request.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/Request.java
@@ -3,19 +3,26 @@ package team07.airbnb.integration.util;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 
+@Component
 public class Request {
 
-    protected ExtractableResponse<Response> get(String url) {
+    @Value("${jwt.host}")
+    private String HOST_TOKEN;
+
+    public ExtractableResponse<Response> get(String url) {
         return RestAssured.given().log().all()
+                .auth().oauth2(HOST_TOKEN)
                 .when()
                 .get(url)
                 .then().log().all()
                 .extract();
     }
 
-    protected ExtractableResponse<Response> post(Object params, String url) {
+    public ExtractableResponse<Response> post(Object params, String url) {
         return RestAssured.given().log().all()
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -25,7 +32,7 @@ public class Request {
                 .extract();
     }
 
-    protected ExtractableResponse<Response> put(Object params, String url) {
+    public ExtractableResponse<Response> put(Object params, String url) {
         return RestAssured.given().log().all()
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -35,7 +42,7 @@ public class Request {
                 .extract();
     }
 
-    protected ExtractableResponse<Response> patch(Object params, String url){
+    public ExtractableResponse<Response> patch(Object params, String url){
         return RestAssured.given().log().all()
             .body(params)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -46,7 +53,7 @@ public class Request {
             .extract();
     }
 
-    protected ExtractableResponse<Response> delete(String url) {
+    public ExtractableResponse<Response> delete(String url) {
         return RestAssured.given().log().all()
                 .when()
                 .delete(url)

--- a/BE/src/test/java/team07/airbnb/integration/util/Request.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/Request.java
@@ -1,0 +1,56 @@
+package team07.airbnb.integration.util;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+public class Request {
+
+    protected ExtractableResponse<Response> get(String url) {
+        return RestAssured.given().log().all()
+                .when()
+                .get(url)
+                .then().log().all()
+                .extract();
+    }
+
+    protected ExtractableResponse<Response> post(Object params, String url) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post(url)
+                .then().log().all()
+                .extract();
+    }
+
+    protected ExtractableResponse<Response> put(Object params, String url) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .put(url)
+                .then().log().all()
+                .extract();
+    }
+
+    protected ExtractableResponse<Response> patch(Object params, String url){
+        return RestAssured.given().log().all()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .patch(url)
+            .then()
+            .log().all()
+            .extract();
+    }
+
+    protected ExtractableResponse<Response> delete(String url) {
+        return RestAssured.given().log().all()
+                .when()
+                .delete(url)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/BE/src/test/java/team07/airbnb/integration/util/Request.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/Request.java
@@ -47,6 +47,21 @@ public class Request {
         return customObjectMapper.readValue(responseJson, responseType);
     }
 
+    public <T> T get(Object params, String url, Class<T> responseType) throws JsonProcessingException {
+        String responseJson = RestAssured.given().log().all()
+                .auth().oauth2(jwtToken)
+                .body(customObjectMapper.writeValueAsString(params))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get(url)
+                .then().log().all()
+                .extract()
+                .asString();
+
+        return customObjectMapper.readValue(responseJson, responseType);
+    }
+
+
     public ExtractableResponse<Response> post(Object params, String url) throws JsonProcessingException {
         return RestAssured.given().log().all()
                 .auth().oauth2(jwtToken)

--- a/BE/src/test/java/team07/airbnb/integration/util/Request.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/Request.java
@@ -24,54 +24,66 @@ public class Request {
     }
 
     public ExtractableResponse<Response> get(String url) {
-        return RestAssured.given().log().all()
-                .auth().oauth2(jwtToken)
+        return RestAssured
+                .given()
+                    .log().all()
+                    .auth().oauth2(jwtToken)
                 .when()
-                .get(url)
-                .then().log().all()
+                    .get(url)
+                .then()
+                    .log().all()
                 .extract();
     }
 
     public <T> T post(Object params, String url, Class<T> responseType) throws JsonProcessingException {
-        return RestAssured.given().log().all()
-                .auth().oauth2(jwtToken)
-                .body(customObjectMapper.writeValueAsString(params))
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+        return RestAssured
+                .given()
+                    .auth().oauth2(jwtToken)
+//                    .header("Authorization", "Bearer " + jwtToken)
+                    .body(customObjectMapper.writeValueAsString(params))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .log().all()
                 .when()
-                .post(url)
+                    .post(url)
                 .then().log().all()
-                .extract()
-                .as(responseType);
+                .extract().as(responseType);
     }
 
     public ExtractableResponse<Response> put(Object params, String url) throws JsonProcessingException {
-        return RestAssured.given().log().all()
-                .auth().oauth2(jwtToken)
-                .body(customObjectMapper.writeValueAsString(params))
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+        return RestAssured
+                .given()
+                    .log().all()
+                    .header("Authorization", "Bearer " + jwtToken)
+                    .body(customObjectMapper.writeValueAsString(params))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .put(url)
-                .then().log().all()
+                    .put(url)
+                .then()
+                    .log().all()
                 .extract();
     }
 
     public ExtractableResponse<Response> patch(Object params, String url) throws JsonProcessingException {
-        return RestAssured.given().log().all()
-                .auth().oauth2(jwtToken)
-                .body(customObjectMapper.writeValueAsString(params))
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+        return RestAssured
+                .given()
+                    .header("Authorization", "Bearer " + jwtToken)
+                    .body(customObjectMapper.writeValueAsString(params))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .log().all()
                 .when()
-                .patch(url)
+                    .patch(url)
                 .then()
-                .log().all()
+                    .log().all()
                 .extract();
     }
 
     public ExtractableResponse<Response> delete(String url) {
-        return RestAssured.given().log().all()
-                .auth().oauth2(jwtToken)
+        return RestAssured
+                .given()
+                    .log().all()
+                    .header("Authorization", "Bearer " + jwtToken)
                 .when()
-                .delete(url)
+                    .delete(url)
                 .then().log().all()
                 .extract();
     }

--- a/BE/src/test/java/team07/airbnb/integration/util/Request.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/Request.java
@@ -23,12 +23,6 @@ public class Request {
         this.jwtToken = jwtToken;
     }
 
-//    private void applyJwtToken() {
-//        if (jwtToken != null) {
-//            RestAssured.given().header("Authorization", "Bearer " + jwtToken);
-//        }
-//    }
-
     public ExtractableResponse<Response> get(String url) {
         return RestAssured.given().log().all()
                 .auth().oauth2(jwtToken)
@@ -38,7 +32,7 @@ public class Request {
                 .extract();
     }
 
-    public ExtractableResponse<Response> post(Object params, String url) throws JsonProcessingException {
+    public <T> T post(Object params, String url, Class<T> responseType) throws JsonProcessingException {
         return RestAssured.given().log().all()
                 .auth().oauth2(jwtToken)
                 .body(customObjectMapper.writeValueAsString(params))
@@ -46,7 +40,8 @@ public class Request {
                 .when()
                 .post(url)
                 .then().log().all()
-                .extract();
+                .extract()
+                .as(responseType);
     }
 
     public ExtractableResponse<Response> put(Object params, String url) throws JsonProcessingException {

--- a/BE/src/test/java/team07/airbnb/integration/util/Request.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/Request.java
@@ -35,18 +35,41 @@ public class Request {
                 .extract();
     }
 
-    public <T> T post(Object params, String url, Class<T> responseType) throws JsonProcessingException {
-        return RestAssured
-                .given()
-                    .auth().oauth2(jwtToken)
-//                    .header("Authorization", "Bearer " + jwtToken)
-                    .body(customObjectMapper.writeValueAsString(params))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .log().all()
+    public <T> T get(String url, Class<T> responseType) throws JsonProcessingException {
+        String responseJson = RestAssured.given().log().all()
+                .auth().oauth2(jwtToken)
+                .when()
+                .get(url)
+                .then().log().all()
+                .extract()
+                .asString();
+
+        return customObjectMapper.readValue(responseJson, responseType);
+    }
+
+    public ExtractableResponse<Response> post(Object params, String url) throws JsonProcessingException {
+        return RestAssured.given().log().all()
+                .auth().oauth2(jwtToken)
+                .body(customObjectMapper.writeValueAsString(params))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                     .post(url)
                 .then().log().all()
-                .extract().as(responseType);
+                .extract();
+    }
+
+    public <T> T post(Object params, String url, Class<T> responseType) throws JsonProcessingException {
+        String responseJson = RestAssured.given().log().all()
+                .auth().oauth2(jwtToken)
+                .body(customObjectMapper.writeValueAsString(params))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post(url)
+                .then().log().all()
+                .extract()
+                .asString();
+
+        return customObjectMapper.readValue(responseJson, responseType);
     }
 
     public ExtractableResponse<Response> put(Object params, String url) throws JsonProcessingException {

--- a/BE/src/test/java/team07/airbnb/integration/util/Request.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/Request.java
@@ -1,8 +1,11 @@
 package team07.airbnb.integration.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -10,21 +13,24 @@ import org.springframework.stereotype.Component;
 @Component
 public class Request {
 
+    @Autowired
+    private ObjectMapper customObjectMapper;
+
     @Value("${jwt.host}")
     private String HOST_TOKEN;
 
     public ExtractableResponse<Response> get(String url) {
         return RestAssured.given().log().all()
-                .auth().oauth2(HOST_TOKEN)
+//                .auth().oauth2(HOST_TOKEN)
                 .when()
                 .get(url)
                 .then().log().all()
                 .extract();
     }
 
-    public ExtractableResponse<Response> post(Object params, String url) {
+    public ExtractableResponse<Response> post(Object params, String url) throws JsonProcessingException {
         return RestAssured.given().log().all()
-                .body(params)
+                .body(customObjectMapper.writeValueAsString(params))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post(url)
@@ -32,9 +38,9 @@ public class Request {
                 .extract();
     }
 
-    public ExtractableResponse<Response> put(Object params, String url) {
+    public ExtractableResponse<Response> put(Object params, String url) throws JsonProcessingException {
         return RestAssured.given().log().all()
-                .body(params)
+                .body(customObjectMapper.writeValueAsString(params))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .put(url)
@@ -42,9 +48,9 @@ public class Request {
                 .extract();
     }
 
-    public ExtractableResponse<Response> patch(Object params, String url){
+    public ExtractableResponse<Response> patch(Object params, String url) throws JsonProcessingException {
         return RestAssured.given().log().all()
-            .body(params)
+            .body(customObjectMapper.writeValueAsString(params))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .when()
             .patch(url)

--- a/BE/src/test/java/team07/airbnb/integration/util/TestConfig.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/TestConfig.java
@@ -1,0 +1,43 @@
+package team07.airbnb.integration.util;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestConfig {
+
+    @Value("${jwt.host}")
+    private String HOST_TOKEN;
+
+    @Value("${jwt.guest}")
+    private String GUEST_TOKEN;
+
+    @Bean(name = "hostRequest")
+    public Request requestInstanceOfHost() {
+        Request request = new Request();
+        request.setJwtToken(HOST_TOKEN);
+
+        return request;
+    }
+
+    @Bean(name = "guestRequest")
+    public Request requestInstanceOfGuest() {
+        Request request = new Request();
+        request.setJwtToken(GUEST_TOKEN);
+
+        return request;
+    }
+
+    @Bean(name = "monkey")
+    public FixtureMonkey fixtureMonkey(){
+        return FixtureMonkey.builder()
+                .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+                .plugin(new JakartaValidationPlugin())
+                .build();
+    }
+}
+

--- a/BE/src/test/java/team07/airbnb/integration/util/TestConfig.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/TestConfig.java
@@ -1,39 +1,46 @@
 package team07.airbnb.integration.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import team07.airbnb.data.user.enums.Role;
 
 @Configuration
 public class TestConfig {
 
-    @Value("${jwt.host}")
-    private String HOST_TOKEN;
-
-    @Value("${jwt.guest}")
-    private String GUEST_TOKEN;
+    @Autowired
+    private AuthHelper authHelper;
 
     @Bean(name = "hostRequest")
-    public Request requestInstanceOfHost() {
+    public Request requestInstanceOfHost() throws JsonProcessingException {
         Request request = new Request();
-        request.setJwtToken(HOST_TOKEN);
+        request.setJwtToken(authHelper.login(Role.HOST));
 
         return request;
     }
 
     @Bean(name = "guestRequest")
-    public Request requestInstanceOfGuest() {
+    public Request requestInstanceOfGuest() throws JsonProcessingException {
         Request request = new Request();
-        request.setJwtToken(GUEST_TOKEN);
+        request.setJwtToken(authHelper.login(Role.USER));
+
+        return request;
+    }
+
+    @Bean(name = "otherRequest")
+    public Request requestInstanceOfOther() throws JsonProcessingException {
+        Request request = new Request();
+        request.setJwtToken(authHelper.login(Role.USER));
 
         return request;
     }
 
     @Bean(name = "monkey")
-    public FixtureMonkey fixtureMonkey(){
+    public FixtureMonkey fixtureMonkey() {
         return FixtureMonkey.builder()
                 .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
                 .plugin(new JakartaValidationPlugin())

--- a/BE/src/test/java/team07/airbnb/integration/util/TestConfig.java
+++ b/BE/src/test/java/team07/airbnb/integration/util/TestConfig.java
@@ -7,13 +7,21 @@ import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPl
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.event.annotation.AfterTestClass;
+import org.springframework.transaction.annotation.Transactional;
 import team07.airbnb.data.user.enums.Role;
 
 @Configuration
+@Transactional
 public class TestConfig {
 
     @Autowired
     private AuthHelper authHelper;
+
+    @AfterTestClass
+    public void afterAll() {
+        authHelper.logout();
+    }
 
     @Bean(name = "hostRequest")
     public Request requestInstanceOfHost() throws JsonProcessingException {
@@ -23,7 +31,7 @@ public class TestConfig {
         return request;
     }
 
-    @Bean(name = "guestRequest")
+    @Bean(name = "userRequest")
     public Request requestInstanceOfGuest() throws JsonProcessingException {
         Request request = new Request();
         request.setJwtToken(authHelper.login(Role.USER));

--- a/BE/src/test/resources/application-test.yml
+++ b/BE/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+spring:
+  config:
+    import:
+      - app_settings/oauth-config.yml
+      - app_settings/jwt-config.yml
+      - app_settings/test-db-config.yml


### PR DESCRIPTION
## 요약
---
### 테스트를 위한 초기 세팅 ⚙️

- RestAssured 사용한 유틸 클래스 추가
- DB 초기화 위한 클래스 추가
- FixtureMonkey : key duplicate 문제 해결 위해 request dto에서 Position 타입 사용하지 않도록 수정 
- 테스트 db 설정 추가
- Request Dto에 validation 추가
- 매 요청마다 JWT를 헤더에 주도록 TestConfig, Request 클래스 수정


### 완성한 테스트코드 👍

1. 예약 API
	- 예약 생성
	- 예약 요금 조회
2. 위시 리스트 API
	- 위시 리스트 추가
	- 위시 리스트 조회
	- 위시 리스트 삭제

## 고민 사항
--- 
- 특정 도메인에 대한 API 통합 테스트 진행할 때 다른 엔티티의 정보가 필요할 경우 어떤 방식이 적절한지 궁금합니다
	1. 직접 더미 데이터를 테스트 진행하기 전에 DB에 임시로 추가 후 사용한 다음, 테스트 완료 후 DB의 데이터 초기화
		- 만약, DB를 직접 다룰 때 PersistenceContext는 어떻게 관리하나요??
	2. 다른 도메인의 서비스를 API 통합 테스트 클래스가 의존하고 있어서 해당 서비스의 메서드를 이용하여 DB에 추가