### PR TITLE
[Team-11] 숙소 검색 API 구현

### DIFF
--- a/be/.gitignore
+++ b/be/.gitignore
@@ -18,3 +18,4 @@ out/
 .vscode/
 
 application.properties
+/src/main/generated/

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -21,6 +21,12 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "com.querydsl:querydsl-bom:5.0.0"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -31,13 +37,25 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // MySQL 데이터베이스 드라이버 의존성 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     implementation 'mysql:mysql-connector-java:8.0.32'
-
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
-
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def generated = 'src/main/generated'
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+clean {
+    delete file(generated)
 }

--- a/be/src/main/java/com/yourbnb/QueryDslConfig.java
+++ b/be/src/main/java/com/yourbnb/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.yourbnb;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/be/src/main/java/com/yourbnb/WebConfig.java
+++ b/be/src/main/java/com/yourbnb/WebConfig.java
@@ -1,0 +1,24 @@
+package com.yourbnb;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/be/src/main/java/com/yourbnb/accommodation/controller/AccommodationController.java
+++ b/be/src/main/java/com/yourbnb/accommodation/controller/AccommodationController.java
@@ -12,7 +12,6 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,7 +28,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 @RestController
 @RequestMapping("/api/accommodations")
 @RequiredArgsConstructor
-@Slf4j
 public class AccommodationController {
     private final AccommodationService accommodationService;
 

--- a/be/src/main/java/com/yourbnb/accommodation/repository/AccommodationRepository.java
+++ b/be/src/main/java/com/yourbnb/accommodation/repository/AccommodationRepository.java
@@ -1,7 +1,8 @@
 package com.yourbnb.accommodation.repository;
 
 import com.yourbnb.accommodation.model.Accommodation;
+import com.yourbnb.search.repository.AccommodationRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AccommodationRepository extends JpaRepository<Accommodation, Long> {
+public interface AccommodationRepository extends AccommodationRepositoryCustom, JpaRepository<Accommodation, Long> {
 }

--- a/be/src/main/java/com/yourbnb/accommodation/service/AccommodationService.java
+++ b/be/src/main/java/com/yourbnb/accommodation/service/AccommodationService.java
@@ -16,6 +16,7 @@ import com.yourbnb.image.service.AccommodationImageService;
 import com.yourbnb.image.util.ImageMapper;
 import com.yourbnb.member.model.Member;
 import com.yourbnb.member.service.MemberService;
+import com.yourbnb.search.dto.AccommodationSearchCondition;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -126,6 +127,19 @@ public class AccommodationService {
         } catch (IllegalArgumentException e) {
             throw new AccommodationNotFoundException(id);
         }
+    }
+
+    /**
+     * 주어진 검색 조건에 따라 숙소를 검색한다.
+     *
+     * @param condition 검색 조건을 담고 있는 객체
+     * @return 검색된 숙소 목록을 AccommodationResponse 객체로 변환한 리스트
+     */
+    @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
+    public List<AccommodationResponse> getSearchedAccommodations(AccommodationSearchCondition condition) {
+        return accommodationRepository.findAccommodationsByCriteria(condition).stream()
+                .map(this::mapAccommodationToResponse)
+                .toList();
     }
 
     private AccommodationImage getAccommodationImage(AccommodationUpdateDto updateDto) {

--- a/be/src/main/java/com/yourbnb/global/GlobalExceptionHandler.java
+++ b/be/src/main/java/com/yourbnb/global/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.yourbnb.global;
 import com.yourbnb.global.exception.InvalidException;
 import com.yourbnb.global.exception.NotFoundException;
 import com.yourbnb.global.exception.ResourceAccessDeniedException;
+import com.yourbnb.search.exception.InvalidCheckInCheckOutDateException;
 import java.io.IOException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
@@ -44,6 +45,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ErrorResponse handleResourceAccessDeniedException(ResourceAccessDeniedException e) {
+        return new ErrorResponse(e.getErrorCode(), e.getErrorMsg());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleInvalidCheckInCheckOutDateException(InvalidCheckInCheckOutDateException e) {
         return new ErrorResponse(e.getErrorCode(), e.getErrorMsg());
     }
 }

--- a/be/src/main/java/com/yourbnb/search/controller/AccommodationSearchController.java
+++ b/be/src/main/java/com/yourbnb/search/controller/AccommodationSearchController.java
@@ -1,0 +1,26 @@
+package com.yourbnb.search.controller;
+
+import com.yourbnb.accommodation.model.dto.AccommodationResponse;
+import com.yourbnb.accommodation.service.AccommodationService;
+import com.yourbnb.search.dto.AccommodationSearchCondition;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/accommodations")
+@RequiredArgsConstructor
+public class AccommodationSearchController {
+    private final AccommodationService accommodationService;
+
+    @GetMapping("/search")
+    @ResponseStatus(HttpStatus.OK)
+    public List<AccommodationResponse> getSearchedAccommodations(AccommodationSearchCondition condition) {
+        // TODO: 체크인 체크아웃 날짜 서로 범위 맞는지 확인
+        return accommodationService.getSearchedAccommodations(condition);
+    }
+}

--- a/be/src/main/java/com/yourbnb/search/controller/AccommodationSearchController.java
+++ b/be/src/main/java/com/yourbnb/search/controller/AccommodationSearchController.java
@@ -20,7 +20,6 @@ public class AccommodationSearchController {
     @GetMapping("/search")
     @ResponseStatus(HttpStatus.OK)
     public List<AccommodationResponse> getSearchedAccommodations(AccommodationSearchCondition condition) {
-        // TODO: 체크인 체크아웃 날짜 서로 범위 맞는지 확인
         return accommodationService.getSearchedAccommodations(condition);
     }
 }

--- a/be/src/main/java/com/yourbnb/search/dto/AccommodationSearchCondition.java
+++ b/be/src/main/java/com/yourbnb/search/dto/AccommodationSearchCondition.java
@@ -1,14 +1,26 @@
 package com.yourbnb.search.dto;
 
+import com.yourbnb.search.exception.InvalidCheckInCheckOutDateException;
 import java.time.LocalDate;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class AccommodationSearchCondition {
     private final String region;
     private final LocalDate checkInDate;
     private final LocalDate checkOutDate;
     private final Integer guestNumber;
+
+    public AccommodationSearchCondition(String region,
+                                        LocalDate checkInDate,
+                                        LocalDate checkOutDate,
+                                        Integer guestNumber) {
+        if (!checkInDate.isBefore(checkOutDate)) {
+            throw new InvalidCheckInCheckOutDateException();
+        }
+        this.region = region;
+        this.checkInDate = checkInDate;
+        this.checkOutDate = checkOutDate;
+        this.guestNumber = guestNumber;
+    }
 }

--- a/be/src/main/java/com/yourbnb/search/dto/AccommodationSearchCondition.java
+++ b/be/src/main/java/com/yourbnb/search/dto/AccommodationSearchCondition.java
@@ -1,0 +1,14 @@
+package com.yourbnb.search.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AccommodationSearchCondition {
+    private final String region;
+    private final LocalDate checkInDate;
+    private final LocalDate checkOutDate;
+    private final Integer guestNumber;
+}

--- a/be/src/main/java/com/yourbnb/search/exception/InvalidCheckInCheckOutDateException.java
+++ b/be/src/main/java/com/yourbnb/search/exception/InvalidCheckInCheckOutDateException.java
@@ -1,0 +1,19 @@
+package com.yourbnb.search.exception;
+
+import lombok.Getter;
+
+public class InvalidCheckInCheckOutDateException extends RuntimeException {
+    private final String ERROR_CODE = "INVALID_CHECK_IN_CHECK_OUT_DATE";
+    private final String ERROR_MSG = "체크인 날짜는 체크아웃 날짜와 같거나 이후일 수 없습니다.";
+
+    @Getter
+    private final String errorCode;
+    @Getter
+    private final String errorMsg;
+
+    public InvalidCheckInCheckOutDateException() {
+        super();
+        this.errorCode = ERROR_CODE;
+        this.errorMsg = ERROR_MSG;
+    }
+}

--- a/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryCustom.java
+++ b/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.yourbnb.search.repository;
+
+import com.yourbnb.accommodation.model.Accommodation;
+import com.yourbnb.search.dto.AccommodationSearchCondition;
+import java.util.List;
+
+public interface AccommodationRepositoryCustom {
+    List<Accommodation> findAccommodationsByCriteria(AccommodationSearchCondition condition);
+}

--- a/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryImpl.java
+++ b/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryImpl.java
@@ -50,14 +50,8 @@ public class AccommodationRepositoryImpl implements AccommodationRepositoryCusto
         final QReservation qReservation = QReservation.reservation;
         return queryFactory.select(qReservation.accommodation.id)
                 .from(qReservation)
-                .where((qReservation.checkInDate.lt(checkOutDate)) // db 체크인 2023-07-16 < 입력 체크아웃 2023-07-15
-                        .and(qReservation.checkOutDate.gt(checkInDate)) // db 체크아웃 2023-07-20 > 입력 체크인 2023-07-10
+                .where((qReservation.checkInDate.lt(checkOutDate))
+                        .and(qReservation.checkOutDate.gt(checkInDate))
                 );
     }
 }
-
-// db 체크인 (16일) =< 입력 체크인 (16일) &&
-// db 체크아웃(20일) >= 입력 체크아웃(20일)
-
-// or db 체크아웃 (20일) 체크인 날짜가 사이
-// db 체크인 (16일) 입력 체크아웃 (19일) 입력 체크인 (17일)

--- a/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryImpl.java
+++ b/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryImpl.java
@@ -50,10 +50,14 @@ public class AccommodationRepositoryImpl implements AccommodationRepositoryCusto
         final QReservation qReservation = QReservation.reservation;
         return queryFactory.select(qReservation.accommodation.id)
                 .from(qReservation)
-                .where(qReservation.checkInDate.goe(checkInDate)
-                        .and(qReservation.checkOutDate.loe(checkOutDate))
-                        .or(qReservation.checkInDate.lt(checkOutDate))
-                        .or(qReservation.checkOutDate.gt(checkInDate))
+                .where((qReservation.checkInDate.lt(checkOutDate)) // db 체크인 2023-07-16 < 입력 체크아웃 2023-07-15
+                        .and(qReservation.checkOutDate.gt(checkInDate)) // db 체크아웃 2023-07-20 > 입력 체크인 2023-07-10
                 );
     }
 }
+
+// db 체크인 (16일) =< 입력 체크인 (16일) &&
+// db 체크아웃(20일) >= 입력 체크아웃(20일)
+
+// or db 체크아웃 (20일) 체크인 날짜가 사이
+// db 체크인 (16일) 입력 체크아웃 (19일) 입력 체크인 (17일)

--- a/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryImpl.java
+++ b/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryImpl.java
@@ -35,7 +35,7 @@ public class AccommodationRepositoryImpl implements AccommodationRepositoryCusto
         if (StringUtils.isEmpty(region)) {
             return qAccommodation.id.isNotNull();
         }
-        return qAccommodation.address.likeIgnoreCase("%" + region + "%");
+        return qAccommodation.address.likeIgnoreCase(region + "%");
     }
 
     private BooleanExpression goeGuestNum(Integer guestNum) {

--- a/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryImpl.java
+++ b/be/src/main/java/com/yourbnb/search/repository/AccommodationRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.yourbnb.search.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yourbnb.accommodation.model.Accommodation;
+import com.yourbnb.accommodation.model.QAccommodation;
+import com.yourbnb.reservation.model.QReservation;
+import com.yourbnb.search.dto.AccommodationSearchCondition;
+import io.micrometer.common.util.StringUtils;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AccommodationRepositoryImpl implements AccommodationRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Accommodation> findAccommodationsByCriteria(AccommodationSearchCondition condition) {
+        final QAccommodation qAccommodation = QAccommodation.accommodation;
+        JPQLQuery<Long> subQuery = getSubQuery(condition.getCheckInDate(), condition.getCheckOutDate());
+
+        return queryFactory.selectFrom(qAccommodation)
+                .where(eqRegion(condition.getRegion()),
+                        goeGuestNum(condition.getGuestNumber()),
+                        qAccommodation.id.notIn(subQuery))
+                .fetch();
+    }
+
+    private BooleanExpression eqRegion(String region) {
+        QAccommodation qAccommodation = QAccommodation.accommodation;
+        if (StringUtils.isEmpty(region)) {
+            return qAccommodation.id.isNotNull();
+        }
+        return qAccommodation.address.likeIgnoreCase("%" + region + "%");
+    }
+
+    private BooleanExpression goeGuestNum(Integer guestNum) {
+        QAccommodation qAccommodation = QAccommodation.accommodation;
+        if (guestNum == null) {
+            return qAccommodation.id.isNotNull();
+        }
+        return qAccommodation.maxCapacity.goe(guestNum);
+    }
+
+    private JPQLQuery<Long> getSubQuery(LocalDate checkInDate, LocalDate checkOutDate) {
+        final QReservation qReservation = QReservation.reservation;
+        return queryFactory.select(qReservation.accommodation.id)
+                .from(qReservation)
+                .where(qReservation.checkInDate.goe(checkInDate)
+                        .and(qReservation.checkOutDate.loe(checkOutDate))
+                        .or(qReservation.checkInDate.lt(checkOutDate))
+                        .or(qReservation.checkOutDate.gt(checkInDate))
+                );
+    }
+}


### PR DESCRIPTION
## ✅ 구현 내용
### Back
- Querydsl을 사용하여 숙소 검색 API 구현
- 검색 조건 : 지역, 체크인/체크아웃, 인원 수

### Front
- 메인페이지, 검색 페이지 구현

<br><br>

## 🤔 고민과 🙋🏻 질문

안녕하세요 노을 🌆

이번 PR에는 Querydsl을 사용하여 특정 조건에 해당하는 숙소를 검색하는 기능을 구현하였습니다. 아직 프론트 페이지가 완성이 되지 않았지만 중간 결과를 보여드리기 위해 간단하게 캡쳐해봤습니다. (아직 배포 전입니다. 🥲)

그리고, 구현을 진행하다 보니 중복 예약을 어떻게 처리해야 할지에 대한 고민이 들었습니다. 저희는 지금 중복 예약이 가능한 상태인데, 다른 팀들을 보니 대기 큐를 사용하거나 호스트가 선택하도록 구현하였는데 실무에서는 어떻게 처리를 하는지 궁금합니다. 🤔


### 메인 페이지
<img width="1552" alt="스크린샷 2024-06-21 오후 5 42 17" src="https://github.com/codesquad-members-2024/be-airdnb/assets/103445254/14e8e5d8-ea9d-49db-836d-bee327e5e633">

<img width="1552" alt="스크린샷 2024-06-21 오후 5 42 21" src="https://github.com/codesquad-members-2024/be-airdnb/assets/103445254/efdd9123-2066-405f-8cbb-ef713c979081">


<img width="1552" alt="스크린샷 2024-06-21 오후 5 42 31" src="https://github.com/codesquad-members-2024/be-airdnb/assets/103445254/c45519b0-e5af-4008-a2cc-23bdba3cd61b">


<br><br>