### PR TITLE
[TEAM-09] 3주차 3번째 pr

### DIFF
--- a/src/main/java/com/airdnb/coupon/CouponController.java
+++ b/src/main/java/com/airdnb/coupon/CouponController.java
@@ -1,6 +1,7 @@
 package com.airdnb.coupon;
 
 import com.airdnb.coupon.dto.CouponDetail;
+import com.airdnb.coupon.dto.CouponRequestResultDetail;
 import com.airdnb.global.ApiResponse;
 import com.airdnb.security.SecurityMemberProvider;
 import java.util.List;
@@ -19,9 +20,29 @@ public class CouponController {
     @PostMapping
     public ApiResponse createCoupon() {
         String currentMemberId = SecurityMemberProvider.getCurrentMemberId();
-        Long couponId = couponService.createCoupon(currentMemberId);
 
-        return ApiResponse.success(couponId);
+        Long position = couponService.requestCoupon(currentMemberId);
+
+        return ApiResponse.success(position);
+    }
+
+    @GetMapping("/queue")
+    public ApiResponse getQueuePosition() {
+        String currentMemberId = SecurityMemberProvider.getCurrentMemberId();
+        Long position = couponService.getQueuePosition(currentMemberId);
+        if (position == null) {
+            return ApiResponse.success("대기열에 존재하지 않습니다.");
+        }
+        return ApiResponse.success(position);
+    }
+
+    @GetMapping("/result")
+    public ApiResponse getCouponRequestResult() {
+        String currentMemberId = SecurityMemberProvider.getCurrentMemberId();
+        CouponRequestResultDetail result = couponService.getCouponRequestResult(currentMemberId);
+        System.out.println(result);
+
+        return ApiResponse.success(result);
     }
 
     @GetMapping

--- a/src/main/java/com/airdnb/coupon/CouponController.java
+++ b/src/main/java/com/airdnb/coupon/CouponController.java
@@ -1,8 +1,11 @@
 package com.airdnb.coupon;
 
+import com.airdnb.coupon.dto.CouponDetail;
 import com.airdnb.global.ApiResponse;
 import com.airdnb.security.SecurityMemberProvider;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +20,15 @@ public class CouponController {
     public ApiResponse createCoupon() {
         String currentMemberId = SecurityMemberProvider.getCurrentMemberId();
         Long couponId = couponService.createCoupon(currentMemberId);
-        
+
         return ApiResponse.success(couponId);
+    }
+
+    @GetMapping
+    public ApiResponse queryCurrentMemberCoupons() {
+        String currentMemberId = SecurityMemberProvider.getCurrentMemberId();
+        List<CouponDetail> coupons = couponService.queryCoupons(currentMemberId);
+
+        return ApiResponse.success(coupons);
     }
 }

--- a/src/main/java/com/airdnb/coupon/CouponController.java
+++ b/src/main/java/com/airdnb/coupon/CouponController.java
@@ -1,0 +1,23 @@
+package com.airdnb.coupon;
+
+import com.airdnb.global.ApiResponse;
+import com.airdnb.security.SecurityMemberProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coupons")
+public class CouponController {
+    private final CouponService couponService;
+
+    @PostMapping
+    public ApiResponse createCoupon() {
+        String currentMemberId = SecurityMemberProvider.getCurrentMemberId();
+        Long couponId = couponService.createCoupon(currentMemberId);
+        
+        return ApiResponse.success(couponId);
+    }
+}

--- a/src/main/java/com/airdnb/coupon/CouponService.java
+++ b/src/main/java/com/airdnb/coupon/CouponService.java
@@ -1,20 +1,27 @@
 package com.airdnb.coupon;
 
 import com.airdnb.coupon.dto.CouponDetail;
+import com.airdnb.coupon.dto.CouponRequestResultDetail;
 import com.airdnb.coupon.entity.Coupon;
+import com.airdnb.coupon.entity.CouponRequestResult;
 import com.airdnb.coupon.entity.CouponStatus;
 import com.airdnb.coupon.repository.AppliedMemberRepository;
 import com.airdnb.coupon.repository.CouponCountRepository;
+import com.airdnb.coupon.repository.CouponQueueRepository;
 import com.airdnb.coupon.repository.CouponRepository;
+import com.airdnb.coupon.repository.CouponRequestResultRepository;
 import com.airdnb.global.exception.InvalidRequestException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class CouponService {
     private static final int MAX_CREATE_COUNT = 100;
     private static final double DISCOUNT_RATE = 50;
@@ -22,7 +29,32 @@ public class CouponService {
     private final CouponRepository couponRepository;
     private final CouponCountRepository couponCountRepository;
     private final AppliedMemberRepository appliedMemberRepository;
+    private final CouponQueueRepository couponQueueRepository;
+    private final CouponRequestResultRepository couponRequestResultRepository;
 
+    public Long requestCoupon(String memberId) {
+        if (couponCountRepository.size() >= MAX_CREATE_COUNT) {
+            throw new InvalidRequestException("쿠폰 발급이 종료되었습니다.");
+        }
+
+        Long queueSize = couponQueueRepository.enqueue(memberId);
+        log.debug("대기큐에 멤버가 추가되었습니다. member = {}, size = {}", memberId, queueSize);
+        return queueSize;
+    }
+
+    @Scheduled(fixedRate = 1000) // 작업 속도 및 한번에 처리할 인원은 여기서 조절
+    public void processQueue() {
+
+        for (int i = 0; i < 50; i++) {
+            String memberId = couponQueueRepository.dequeue();
+            if (memberId != null) {
+                log.debug("작업이 시작됩니다 member = {}", memberId);
+                CouponRequestResult couponRequestResult = processCouponRequest(memberId);
+                couponRequestResultRepository.save(couponRequestResult);
+                log.debug("작업이 끝났습니다. size = {}", couponQueueRepository.size());
+            }
+        }
+    }
 
     public Long createCoupon(String memberId) {
         Long added = appliedMemberRepository.add(memberId);
@@ -42,10 +74,34 @@ public class CouponService {
     }
 
     @Transactional(readOnly = true)
+    public Long getQueuePosition(String memberId) {
+        return couponQueueRepository.getPosition(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public CouponRequestResultDetail getCouponRequestResult(String memberId) {
+        List<CouponRequestResult> couponRequestResults = couponRequestResultRepository.findAllByMemberId(memberId);
+        if (couponRequestResults.isEmpty()) {
+            throw new InvalidRequestException("해당 사용자에 대한 쿠폰 발급 요청 결과가 존재하지 않습니다.");
+        }
+        CouponRequestResult latest = couponRequestResults.get(couponRequestResults.size() - 1);
+        return CouponRequestResultDetail.from(latest);
+    }
+
+    @Transactional(readOnly = true)
     public List<CouponDetail> queryCoupons(String memberId) {
         List<Coupon> coupons = couponRepository.findAllByMemberId(memberId);
         return coupons.stream()
                 .map(CouponDetail::from)
                 .toList();
+    }
+
+    private CouponRequestResult processCouponRequest(String memberId) {
+        try {
+            Long couponId = createCoupon(memberId);
+            return new CouponRequestResult(memberId, true, couponId, null);
+        } catch (InvalidRequestException e) {
+            return new CouponRequestResult(memberId, false, null, e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/airdnb/coupon/CouponService.java
+++ b/src/main/java/com/airdnb/coupon/CouponService.java
@@ -1,11 +1,13 @@
 package com.airdnb.coupon;
 
+import com.airdnb.coupon.dto.CouponDetail;
 import com.airdnb.coupon.entity.Coupon;
 import com.airdnb.coupon.entity.CouponStatus;
 import com.airdnb.coupon.repository.AppliedMemberRepository;
 import com.airdnb.coupon.repository.CouponCountRepository;
 import com.airdnb.coupon.repository.CouponRepository;
 import com.airdnb.global.exception.InvalidRequestException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,5 +39,13 @@ public class CouponService {
         Coupon coupon = new Coupon(DISCOUNT_RATE, CouponStatus.ACTIVE, memberId);
         couponRepository.save(coupon);
         return coupon.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CouponDetail> queryCoupons(String memberId) {
+        List<Coupon> coupons = couponRepository.findAllByMemberId(memberId);
+        return coupons.stream()
+                .map(CouponDetail::from)
+                .toList();
     }
 }

--- a/src/main/java/com/airdnb/coupon/CouponService.java
+++ b/src/main/java/com/airdnb/coupon/CouponService.java
@@ -1,0 +1,41 @@
+package com.airdnb.coupon;
+
+import com.airdnb.coupon.entity.Coupon;
+import com.airdnb.coupon.entity.CouponStatus;
+import com.airdnb.coupon.repository.AppliedMemberRepository;
+import com.airdnb.coupon.repository.CouponCountRepository;
+import com.airdnb.coupon.repository.CouponRepository;
+import com.airdnb.global.exception.InvalidRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CouponService {
+    private static final int MAX_CREATE_COUNT = 100;
+    private static final double DISCOUNT_RATE = 50;
+
+    private final CouponRepository couponRepository;
+    private final CouponCountRepository couponCountRepository;
+    private final AppliedMemberRepository appliedMemberRepository;
+
+
+    public Long createCoupon(String memberId) {
+        Long added = appliedMemberRepository.add(memberId);
+        if (added != 1) {
+            throw new InvalidRequestException("이미 쿠폰이 발급된 사용자입니다.");
+        }
+
+        Long couponCount = couponCountRepository.increment();
+
+        if (couponCount > MAX_CREATE_COUNT) {
+            throw new InvalidRequestException("발급 가능한 쿠폰이 모두 소진되었습니다.");
+        }
+
+        Coupon coupon = new Coupon(DISCOUNT_RATE, CouponStatus.ACTIVE, memberId);
+        couponRepository.save(coupon);
+        return coupon.getId();
+    }
+}

--- a/src/main/java/com/airdnb/coupon/dto/CouponDetail.java
+++ b/src/main/java/com/airdnb/coupon/dto/CouponDetail.java
@@ -1,0 +1,20 @@
+package com.airdnb.coupon.dto;
+
+import com.airdnb.coupon.entity.Coupon;
+import com.airdnb.coupon.entity.CouponStatus;
+import lombok.Value;
+
+@Value
+public class CouponDetail {
+    Long id;
+
+    Double discountRate;
+
+    CouponStatus status;
+
+    String memberId;
+
+    public static CouponDetail from(Coupon coupon) {
+        return new CouponDetail(coupon.getId(), coupon.getDiscountRate(), coupon.getStatus(), coupon.getMemberId());
+    }
+}

--- a/src/main/java/com/airdnb/coupon/dto/CouponRequestResultDetail.java
+++ b/src/main/java/com/airdnb/coupon/dto/CouponRequestResultDetail.java
@@ -1,0 +1,26 @@
+package com.airdnb.coupon.dto;
+
+import com.airdnb.coupon.entity.CouponRequestResult;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@Getter
+@ToString
+public class CouponRequestResultDetail {
+    private Long couponId;
+    private boolean processed;
+    private String failureReason;
+
+    public CouponRequestResultDetail(Long couponId, boolean processed, String failureReason) {
+        this.couponId = couponId;
+        this.processed = processed;
+        this.failureReason = failureReason;
+    }
+
+    public static CouponRequestResultDetail from(CouponRequestResult couponRequestResult) {
+        return new CouponRequestResultDetail(couponRequestResult.getCouponId(), couponRequestResult.isProcessed(),
+                couponRequestResult.getFailureReason());
+    }
+}

--- a/src/main/java/com/airdnb/coupon/entity/Coupon.java
+++ b/src/main/java/com/airdnb/coupon/entity/Coupon.java
@@ -1,0 +1,34 @@
+package com.airdnb.coupon.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Double discountRate;
+    
+    @Enumerated(EnumType.STRING)
+    private CouponStatus status;
+
+    private String memberId;
+
+    public Coupon(Double discountRate, CouponStatus status, String memberId) {
+        this.discountRate = discountRate;
+        this.status = status;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/airdnb/coupon/entity/CouponRequestResult.java
+++ b/src/main/java/com/airdnb/coupon/entity/CouponRequestResult.java
@@ -1,0 +1,31 @@
+package com.airdnb.coupon.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CouponRequestResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String memberId;
+    private boolean processed;
+    private Long couponId;
+    private String failureReason;
+
+    public CouponRequestResult(String memberId, boolean processed, Long couponId, String failureReason) {
+        this.memberId = memberId;
+        this.processed = processed;
+        this.couponId = couponId;
+        this.failureReason = failureReason;
+    }
+}

--- a/src/main/java/com/airdnb/coupon/entity/CouponStatus.java
+++ b/src/main/java/com/airdnb/coupon/entity/CouponStatus.java
@@ -1,0 +1,5 @@
+package com.airdnb.coupon.entity;
+
+public enum CouponStatus {
+    ACTIVE, USED
+}

--- a/src/main/java/com/airdnb/coupon/repository/AppliedMemberRepository.java
+++ b/src/main/java/com/airdnb/coupon/repository/AppliedMemberRepository.java
@@ -1,0 +1,22 @@
+package com.airdnb.coupon.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class AppliedMemberRepository {
+    private static final String APPLIED_MEMBER_KEY = "applied_member";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public Long add(String memberId) {
+        return redisTemplate.opsForSet()
+                .add(APPLIED_MEMBER_KEY, memberId);
+    }
+
+    public void clear() {
+        redisTemplate.delete(APPLIED_MEMBER_KEY);
+    }
+}

--- a/src/main/java/com/airdnb/coupon/repository/CouponCountRepository.java
+++ b/src/main/java/com/airdnb/coupon/repository/CouponCountRepository.java
@@ -19,6 +19,11 @@ public class CouponCountRepository {
                 .increment(COUPON_COUNT_KEY);
     }
 
+    public Long size() {
+        return redisTemplate.opsForValue()
+                .size(COUPON_COUNT_KEY);
+    }
+
     public void clear() {
         redisTemplate.delete(COUPON_COUNT_KEY);
     }

--- a/src/main/java/com/airdnb/coupon/repository/CouponCountRepository.java
+++ b/src/main/java/com/airdnb/coupon/repository/CouponCountRepository.java
@@ -1,0 +1,25 @@
+package com.airdnb.coupon.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CouponCountRepository {
+
+    private static final String COUPON_COUNT_KEY = "coupon_count";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+
+    public Long increment() {
+        return redisTemplate
+                .opsForValue()
+                .increment(COUPON_COUNT_KEY);
+    }
+
+    public void clear() {
+        redisTemplate.delete(COUPON_COUNT_KEY);
+    }
+}

--- a/src/main/java/com/airdnb/coupon/repository/CouponQueueRepository.java
+++ b/src/main/java/com/airdnb/coupon/repository/CouponQueueRepository.java
@@ -1,0 +1,33 @@
+package com.airdnb.coupon.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CouponQueueRepository {
+    private static final String COUPON_QUEUE_KEY = "coupon_queue";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public Long enqueue(String memberId) {
+        return redisTemplate.opsForList().rightPush(COUPON_QUEUE_KEY, memberId);
+    }
+
+    public String dequeue() {
+        return redisTemplate.opsForList().leftPop(COUPON_QUEUE_KEY);
+    }
+
+    public Long getPosition(String memberId) {
+        return redisTemplate.opsForList().indexOf(COUPON_QUEUE_KEY, memberId);
+    }
+
+    public Long size() {
+        return redisTemplate.opsForList().size(COUPON_QUEUE_KEY);
+    }
+
+    public void clear() {
+        redisTemplate.delete(COUPON_QUEUE_KEY);
+    }
+}

--- a/src/main/java/com/airdnb/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/airdnb/coupon/repository/CouponRepository.java
@@ -1,7 +1,11 @@
 package com.airdnb.coupon.repository;
 
 import com.airdnb.coupon.entity.Coupon;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+    @Query
+    List<Coupon> findAllByMemberId(String memberId);
 }

--- a/src/main/java/com/airdnb/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/airdnb/coupon/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package com.airdnb.coupon.repository;
+
+import com.airdnb.coupon.entity.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/com/airdnb/coupon/repository/CouponRequestResultRepository.java
+++ b/src/main/java/com/airdnb/coupon/repository/CouponRequestResultRepository.java
@@ -1,0 +1,9 @@
+package com.airdnb.coupon.repository;
+
+import com.airdnb.coupon.entity.CouponRequestResult;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRequestResultRepository extends JpaRepository<CouponRequestResult, Long> {
+    List<CouponRequestResult> findAllByMemberId(String memberId);
+}

--- a/src/main/java/com/airdnb/security/SecurityMemberProvider.java
+++ b/src/main/java/com/airdnb/security/SecurityMemberProvider.java
@@ -1,0 +1,9 @@
+package com.airdnb.security;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityMemberProvider {
+    public static String getCurrentMemberId() {
+        return SecurityContextHolder.getContext().getAuthentication().getName();
+    }
+}

--- a/src/main/java/com/airdnb/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/airdnb/security/jwt/JwtAuthenticationFilter.java
@@ -26,8 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-        throws ServletException, IOException {
-
+            throws ServletException, IOException {
         String token = jwtUtil.getToken(request.getHeader(SecurityConstants.AUTHORIZATION_HEADER));
 
         if (token == null) {
@@ -47,8 +46,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String id = jwtUtil.getId(token);
             SecurityMember securityMember = memberSecurityService.loadUserByUsername(id);
             if (securityMember != null) {
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(securityMember, null,
-                    securityMember.getAuthorities());
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        securityMember, null,
+                        securityMember.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.info("Security Context에 '{}' 인증 정보를 저장했습니다.", id);
             }

--- a/src/test/java/com/airdnb/coupon/CouponServiceTest.java
+++ b/src/test/java/com/airdnb/coupon/CouponServiceTest.java
@@ -1,0 +1,89 @@
+package com.airdnb.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.airdnb.coupon.repository.AppliedMemberRepository;
+import com.airdnb.coupon.repository.CouponCountRepository;
+import com.airdnb.coupon.repository.CouponRepository;
+import com.airdnb.member.MemberRepository;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CouponServiceTest {
+    @Autowired
+    CouponRepository couponRepository;
+    @Autowired
+    CouponCountRepository couponCountRepository;
+    @Autowired
+    AppliedMemberRepository appliedMemberRepository;
+    @Autowired
+    CouponService couponService;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        couponRepository.deleteAll();
+        couponCountRepository.clear();
+        appliedMemberRepository.clear();
+    }
+
+    @Test
+    void _1000명_접근시_쿠폰_발급() throws InterruptedException {
+        int threadCount = 1000;
+        AtomicInteger errorCount = new AtomicInteger();
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            String memberId = "member" + i;
+            executorService.submit(() -> {
+                try {
+                    couponService.createCoupon(memberId);
+                } catch (Exception e) {
+                    errorCount.getAndIncrement();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        long couponCount = couponRepository.count();
+        assertThat(couponCount).isEqualTo(100);
+        assertThat(errorCount.get()).isEqualTo(900);
+    }
+
+    @Test
+    void _1명에게_1개의_쿠폰_발급() throws InterruptedException {
+        int threadCount = 1000;
+        AtomicInteger errorCount = new AtomicInteger();
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            String memberId = "member" + 1;
+            executorService.submit(() -> {
+                try {
+                    couponService.createCoupon(memberId);
+                } catch (Exception e) {
+                    errorCount.getAndIncrement();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        long couponCount = couponRepository.count();
+        assertThat(couponCount).isEqualTo(1);
+        assertThat(errorCount.get()).isEqualTo(999);
+    }
+}


### PR DESCRIPTION
## 구현 내용

- 선착순 쿠폰 발급 기능 구현
  - 최대 100 개의 쿠폰, 1명당 1장씩 발급 가능합니다.
  - 동시성 문제를 해결하기 위해 redis를 이용하였습니다.
    - redis를 사용하지 않았을 때는 동시에 1000명이 접근하면 100개 이상의 쿠폰이 발급되었습니다. 
  - 지금은 한가지 종류의 쿠폰만 발급하고 있는데 CouponType이라는 Entity를 만들어 관리하면 여러 종류의 쿠폰도 구현 가능할 것 같습니다.

- 유저 아이디와 일치하는 쿠폰 리스트 조회 기능 구현
- 대기열 기능 구현
  - 선착순 쿠폰 이벤트는 보통 서버에 많은 부하를 일으킵니다. 따라서 처리량을 조절하도록 대기열 큐 기능을 구현하였습니다.
    - redis의 List를 사용하여 대기열 큐를 구현하였습니다.
    - kafka 등으로 대체 가능할 것 같지만 너무 무거우므로 redis로 충분하다고 생각했습니다.